### PR TITLE
Fix typo and remove redundant blank space

### DIFF
--- a/guide/src/descriptor_sets/descriptor_buffer.md
+++ b/guide/src/descriptor_sets/descriptor_buffer.md
@@ -1,6 +1,6 @@
 # Descriptor Buffer
 
-Uniform and Storage buffers need to be N-buffered unless they are "GPU const", ie contents do not change after creation.  Encapsulate a `vma::Buffer` per virtual frame in a `DescriptorBuffer`:
+Uniform and Storage buffers need to be N-buffered unless they are "GPU const", ie contents do not change after creation. Encapsulate a `vma::Buffer` per virtual frame in a `DescriptorBuffer`:
 
 ```cpp
 class DescriptorBuffer {

--- a/guide/src/initialization/device.md
+++ b/guide/src/initialization/device.md
@@ -2,7 +2,7 @@
 
 A [Vulkan Device](https://docs.vulkan.org/spec/latest/chapters/devsandqueues.html#devsandqueues-devices) is a logical instance of a Physical Device, and will the primary interface for everything Vulkan now onwards. [Vulkan Queues](https://docs.vulkan.org/spec/latest/chapters/devsandqueues.html#devsandqueues-queues) are owned by the Device, we will need one from the queue family stored in the `Gpu` to submit recorded command buffers. We also need to explicitly declare all features we want to use, eg [Dynamic Rendering](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_dynamic_rendering.html) and [Synchronization2](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_synchronization2.html).
 
-Setup a `vk::QueueCreateInfo` object:
+Setup a `vk::DeviceQueueCreateInfo` object:
 
 ```cpp
 auto queue_ci = vk::DeviceQueueCreateInfo{};

--- a/guide/src/initialization/instance.md
+++ b/guide/src/initialization/instance.md
@@ -16,7 +16,7 @@ constexpr auto vk_version_v = VK_MAKE_VERSION(1, 3, 0);
 } // namespace
 ```
 
-In `App`, create  a new member function `create_instance()` and call it after `create_window()` in `run()`. After initializing the dispatcher, check that the loader meets the version requirement:
+In `App`, create a new member function `create_instance()` and call it after `create_window()` in `run()`. After initializing the dispatcher, check that the loader meets the version requirement:
 
 ```cpp
 void App::create_instance() {

--- a/guide/src/initialization/scoped_waiter.md
+++ b/guide/src/initialization/scoped_waiter.md
@@ -2,7 +2,7 @@
 
 A useful abstraction to have is an object that in its destructor waits/blocks until the Device is idle. It is incorrect usage to destroy Vulkan objects while they are in use by the GPU, such an object helps with making sure the device is idle before some dependent resource gets destroyed.
 
-Being able to do arbitary things on scope exit will be useful in other spots too, so we encapsulate that in a basic class template `Scoped`. It's somewhat like a `unique_ptr<Type, Deleter>` that stores the value (`Type`) instead of a pointer (`Type*`), with some constraints:
+Being able to do arbitrary things on scope exit will be useful in other spots too, so we encapsulate that in a basic class template `Scoped`. It's somewhat like a `unique_ptr<Type, Deleter>` that stores the value (`Type`) instead of a pointer (`Type*`), with some constraints:
 
 1. `Type` must be default constructible
 1. Assumes a default constructed `Type` is equivalent to null (does not call `Deleter`)

--- a/guide/translations/ko-KR/src/initialization/device.md
+++ b/guide/translations/ko-KR/src/initialization/device.md
@@ -2,7 +2,7 @@
 
 [디바이스](https://docs.vulkan.org/spec/latest/chapters/devsandqueues.html#devsandqueues-devices)는 Physical Device의 논리적 인스턴스이며, 이후의 모든 Vulkan 작업에서 주요 인터페이스 역할을 하게 됩니다. [큐](https://docs.vulkan.org/spec/latest/chapters/devsandqueues.html#devsandqueues-queues)는 디바이스가 소유하는 것으로, `Gpu` 구조체에 저장된 큐 패밀리에서 하나를 가져와 기록된 커맨드 버퍼를 제출하는 데 사용할 것입니다. 또한 사용하기를 원하는 [Dynamic Rendering](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_dynamic_rendering.html) 과 [Synchronization2](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_synchronization2.html)같은 기능들을 명시적으로 선언해야 합니다.
 
-`vk::QueueCreateInfo`객체를 설정합시다.
+`vk::DeviceQueueCreateInfo`객체를 설정합시다.
 
 ```cpp
 auto queue_ci = vk::DeviceQueueCreateInfo{};


### PR DESCRIPTION
- Correct `vk::QueueCreateInfo` to `vk::DeviceQueueCreateInfo` in the guide
- Remove redundant blank space